### PR TITLE
Corrects bug with normalisation ranges in battery

### DIFF
--- a/DRL_battery.py
+++ b/DRL_battery.py
@@ -222,16 +222,16 @@ with mlflow.start_run(run_name=name):
     if args.normalization:
         # We have to know what dictionary ranges to use
         norm_range = None
-        env_type = args.environment.split('-')[2]
+        env_type = args.environment.split('-')[1]
         if env_type == 'datacenter':
-            range = RANGES_5ZONE
+            norm_range = RANGES_DATACENTER
         elif env_type == '5Zone':
-            range = RANGES_IW
+            norm_range = RANGES_5ZONE
         elif env_type == 'IWMullion':
-            range = RANGES_DATACENTER
+            norm_range = RANGES_IW
         else:
             raise NameError('env_type is not valid, check environment name')
-        env = NormalizeObservation(env, ranges=range)
+        env = NormalizeObservation(env, ranges=norm_range)
     if args.logger:
         env = LoggerWrapper(env)
     if args.multiobs:

--- a/examples/DRL_usage.py
+++ b/examples/DRL_usage.py
@@ -181,16 +181,16 @@ with mlflow.start_run(run_name=name):
     if args.normalization:
         # We have to know what dictionary ranges to use
         norm_range = None
-        env_type = args.environment.split('-')[2]
+        env_type = args.environment.split('-')[1]
         if env_type == 'datacenter':
-            range = RANGES_5ZONE
+            norm_range = RANGES_DATACENTER
         elif env_type == '5Zone':
-            range = RANGES_IW
+            norm_range = RANGES_5ZONE
         elif env_type == 'IWMullion':
-            range = RANGES_DATACENTER
+            norm_range = RANGES_IW
         else:
             raise NameError('env_type is not valid, check environment name')
-        env = NormalizeObservation(env)
+        env = NormalizeObservation(env, ranges=norm_range)
     if args.logger:
         env = LoggerWrapper(env)
     if args.multiobs:


### PR DESCRIPTION
Aims to correct minor bugs with normalisation in the DRL battery

Wrong keyword extracted from environment name
Normalisation ranges inconsistent with the extracted keyword from environment
Normalisation ranges not passed to gym environment in DRL usage (correct in DRL battery)
(minor: change variable name from range to norm_range, as I suppose it was introduced for this purpose before)