### PR TITLE
Dynamic observation/action spaces for Sinergym (vX.Y.Z)

### DIFF
--- a/.github/workflows/merge_pr.yml
+++ b/.github/workflows/merge_pr.yml
@@ -100,7 +100,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Build the latest Docker image
         if: "${{ env.DOCKER_USER != '' && env.DOCKER_PASSWORD != '' }}"
-        run: docker build . --file Dockerfile --build-arg SINERGYM_EXTRAS=[extra] --tag $DOCKER_USER/sinergym:latest
+        run: docker build . --file Dockerfile --build-arg SINERGYM_EXTRAS=[extras] --tag $DOCKER_USER/sinergym:latest
       - name: Login in Docker Hub account
         if: "${{ env.DOCKER_USER != '' && env.DOCKER_PASSWORD != '' }}"
         run: docker login -u $DOCKER_USER -p $DOCKER_PASSWORD

--- a/example.py
+++ b/example.py
@@ -1,4 +1,5 @@
 import xml.etree.ElementTree as ET
+from xml.dom import minidom
 
 config_params = {
     'observation_variables': [
@@ -17,9 +18,18 @@ config_params = {
         'Zone Thermal Comfort Fanger Model PPD (SPACE1-1 PEOPLE 1)',
         'Zone People Occupant Count (SPACE1-1)',
         'People Air Temperature (SPACE1-1 PEOPLE 1)',
-        'Facility Total HVAC Electricity Demand Rate (Whole Building)']}
+        'Facility Total HVAC Electricity Demand Rate (Whole Building)'],
+    'action_variables': [
+        'West-HtgSetP-RL',
+        'West-ClgSetP-RL',
+        'East-HtgSetP-RL',
+        'East-ClgSetP-RL']}
+
+config_params = {}
 
 variables_custom = ET.Element('BCVTB-variables')
+
+variables_custom.append(ET.Comment('Receivedjeje from EnergyPlus'))
 
 if 'observation_variables' in config_params:
     for variable in config_params['observation_variables']:
@@ -36,5 +46,19 @@ if 'observation_variables' in config_params:
             name=variable_zone,
             type=variable_name)
 
-arbol = ET.ElementTree(variables_custom)
-arbol.write("./prueba.xml")
+else:
+    # Copy default variables.cfg
+    tree = ET.parse('./sinergym/data/variables/variablesDXVAV.cfg')
+    default_variables = tree.getroot()
+    for var in default_variables.findall('variable'):
+        if var.attrib['source'] == 'EnergyPlus':
+            variables_custom.append(var)
+
+xmlstr = minidom.parseString(
+    ET.tostring(variables_custom)).toprettyxml(
+        indent="   ")
+with open("prueba.cfg", "w") as f:
+    f.write(xmlstr)
+
+# arbol = ET.ElementTree(variables_custom)
+# arbol.write("./prueba.xml")

--- a/example.py
+++ b/example.py
@@ -1,0 +1,40 @@
+import xml.etree.ElementTree as ET
+
+config_params = {
+    'observation_variables': [
+        'Site Outdoor Air Drybulb Temperature (Environment)',
+        'Site Outdoor Air Relative Humidity (Environment)',
+        'Site Wind Speed (Environment)',
+        'Site Wind Direction (Environment)',
+        'Site Diffuse Solar Radiation Rate per Area (Environment)',
+        'Site Direct Solar Radiation Rate per Area (Environment)',
+        'Zone Thermostat Heating Setpoint Temperature (SPACE1-1)',
+        'Zone Thermostat Cooling Setpoint Temperature (SPACE1-1)',
+        'Zone Air Temperature (SPACE1-1)',
+        'Zone Thermal Comfort Mean Radiant Temperature (SPACE1-1 PEOPLE 1)',
+        'Zone Air Relative Humidity (SPACE1-1)',
+        'Zone Thermal Comfort Clothing Value (SPACE1-1 PEOPLE 1)',
+        'Zone Thermal Comfort Fanger Model PPD (SPACE1-1 PEOPLE 1)',
+        'Zone People Occupant Count (SPACE1-1)',
+        'People Air Temperature (SPACE1-1 PEOPLE 1)',
+        'Facility Total HVAC Electricity Demand Rate (Whole Building)']}
+
+variables_custom = ET.Element('BCVTB-variables')
+
+if 'observation_variables' in config_params:
+    for variable in config_params['observation_variables']:
+        # variable = "<variable_name> (<variable_zone>)"
+        variable_elements = variable.split('(')
+        variable_name = variable_elements[0]
+        variable_zone = variable_elements[1][:-1]
+
+        new_xml_variable = ET.SubElement(
+            variables_custom, 'variable', source='EnergyPlus')
+        ET.SubElement(
+            new_xml_variable,
+            'EnergyPlus',
+            name=variable_zone,
+            type=variable_name)
+
+arbol = ET.ElementTree(variables_custom)
+arbol.write("./prueba.xml")

--- a/sinergym/envs/eplus_env.py
+++ b/sinergym/envs/eplus_env.py
@@ -37,7 +37,7 @@ class EplusEnv(gym.Env):
         discrete_actions: bool = True,
         weather_variability: Optional[Tuple[float]] = None,
         reward: Any = LinearReward(),
-        config_params: Optional[Dict[str, Any]] = None
+        config_params: Dict[str, Any] = {}
     ):
         """Environment with EnergyPlus simulator.
 
@@ -50,8 +50,12 @@ class EplusEnv(gym.Env):
             discrete_actions (bool, optional): Whether the actions are discrete (True) or continuous (False). Defaults to True.
             weather_variability (Optional[Tuple[float]], optional): Tuple with sigma, mu and tao of the Ornstein-Uhlenbeck process to be applied to weather data. Defaults to None.
             reward (Any, optional): Reward function instance used for agent feedback. Defaults to LinearReward().
-            config_params (Optional[Dict[str, Any]], optional): Dictionary with all extra configuration for simulator. Defaults to None.
+            config_params (Dict[str, Any], optional): Dictionary with all extra configuration for simulator. Defaults to empty Dict.
         """
+
+        # ---------------------------------------------------------------------------- #
+        #                               PATHS DEFINITION                               #
+        # ---------------------------------------------------------------------------- #
         eplus_path = os.environ['EPLUS_PATH']
         bcvtb_path = os.environ['BCVTB_PATH']
         self.pkg_data_path = pkg_resources.resource_filename(
@@ -65,60 +69,125 @@ class EplusEnv(gym.Env):
         self.spaces_path = os.path.join(
             self.pkg_data_path, 'variables', spaces_file)
 
+        # ---------------------------------------------------------------------------- #
+        #                             SIMULATOR DEFINITION                             #
+        # ---------------------------------------------------------------------------- #
         self.simulator = EnergyPlus(
             env_name=env_name,
             eplus_path=eplus_path,
             bcvtb_path=bcvtb_path,
             idf_path=self.idf_path,
             weather_path=self.weather_path,
-            variable_path=self.variables_path,
+            variables_path=self.variables_path,
             config_params=config_params
         )
 
-        # parse variables (observation and action) from cfg file
-        self.variables = parse_variables(self.variables_path)
+        # ---------------------------------------------------------------------------- #
+        #                               OTHERS ATTRIBUTES                              #
+        # ---------------------------------------------------------------------------- #
 
         # Random noise to apply for weather series
         self.weather_variability = weather_variability
+        # Action space flag
+        self.flag_discrete = discrete_actions
+        # Reward class
+        self.cls_reward = reward
+        # ONLY FOR CONTINUOUS ACTION
+        self.setpoints_space = None
 
-        # parse observation and action spaces from spaces_path
+        # ---------------------------------------------------------------------------- #
+        #                      VARIABLES ATTRIBUTE FOR ENVIRONMENT                     #
+        # ---------------------------------------------------------------------------- #
+        # By default, self.variables has variables.cfg path values
+        self.variables = parse_variables(self.variables_path)
+        # Changed by custom variables if they are specified
+        if config_params.get('observation_variables'):
+            self.variables['observation'] = config_params['observation_variables']
+        if config_params.get('action_variables'):
+            self.variables['action'] = config_params['action_variables']
+
+        # ---------------------------------------------------------------------------- #
+        #                       DEFAULT ACTION/OBSERVATION SPACE                       #
+        # ---------------------------------------------------------------------------- #
+        # Parse observation and action spaces from spaces_path
         space = parse_observation_action_space(self.spaces_path)
         observation_def = space['observation']
         discrete_action_def = space['discrete_action']
         continuous_action_def = space['continuous_action']
 
-        # Observation space
-        self.observation_space = gym.spaces.Box(
-            low=observation_def[0],
-            high=observation_def[1],
-            shape=observation_def[2],
-            dtype=observation_def[3])
+        # ---------------------------------------------------------------------------- #
+        #                         CUSTOM OBSERVATION DEFINITION                        #
+        # ---------------------------------------------------------------------------- #
 
-        # Action space
-        self.flag_discrete = discrete_actions
-
-        # Discrete
-        if self.flag_discrete:
-            self.action_mapping = discrete_action_def
-            self.action_space = gym.spaces.Discrete(len(discrete_action_def))
-        # Continuous
+        # Custom observation variables has been specified in config_params
+        if config_params.get('observation_space'):
+            self.observation_space = config_params['observation_space']
+        # Else Default environment Observation space
         else:
-            # Defining action values setpoints (one per value)
-            self.action_setpoints = []
-            for i in range(len(self.variables['action'])):
-                # action_variable --> [low,up]
-                self.action_setpoints.append([
-                    continuous_action_def[0][i], continuous_action_def[1][i]])
+            self.observation_space = gym.spaces.Box(
+                low=observation_def[0],
+                high=observation_def[1],
+                shape=observation_def[2],
+                dtype=observation_def[3])
 
-            self.action_space = gym.spaces.Box(
-                # continuous_action_def[2] --> shape
-                low=np.repeat(-1, continuous_action_def[2][0]),
-                high=np.repeat(1, continuous_action_def[2][0]),
-                dtype=continuous_action_def[3]
-            )
+        # ---------------------------------------------------------------------------- #
+        #                           CUSTOM ACTION DEFINITION                           #
+        # ---------------------------------------------------------------------------- #
+        # Custom action variables has been specified in config_params
+        if config_params.get('action_space'):
+            if isinstance(config_params['action_space'], gym.spaces.Box):
+                # Normalize action_space to [-1,1] in all variables and save
+                # original
+                self.setpoints_space = config_params['action_space']
+                self.action_space = gym.spaces.Box(low=np.repeat(-1,
+                                                                 len(self.variables['action'])),
+                                                   high=np.repeat(1,
+                                                                  len(self.variables['action'])),
+                                                   dtype=np.float32)
+            elif self.flag_discrete and not isinstance(config_params['action_space'], gym.spaces.Box):
+                self.action_space = config_params['action_space']
+                self.action_mapping = config_params['action_mapping']
+            else:
+                raise RuntimeError('Custom action specification has no sense.')
 
-        # Reward class
-        self.cls_reward = reward
+        # Else Default environment action space
+        else:
+            # Discrete
+            if self.flag_discrete:
+                self.action_mapping = discrete_action_def
+                self.action_space = gym.spaces.Discrete(
+                    len(discrete_action_def))
+            # Continuous
+            else:
+                # Defining action values setpoints (one per value)
+                for i in range(len(self.variables['action'])):
+                    # action_variable --> [low,up]
+                    # CAMBIAAAAAAR
+                    self.action_setpoints.append([
+                        continuous_action_def[0][i], continuous_action_def[1][i]])
+
+                self.action_space = gym.spaces.Box(
+                    # continuous_action_def[2] --> shape
+                    low=np.repeat(-1, continuous_action_def[2][0]),
+                    high=np.repeat(1, continuous_action_def[2][0]),
+                    dtype=continuous_action_def[3]
+                )
+
+    def reset(self) -> np.ndarray:
+        """Reset the environment.
+
+        Returns:
+            np.ndarray: Current observation.
+        """
+        # Change to next episode
+        time_info, obs, done = self.simulator.reset(self.weather_variability)
+        obs_dict = dict(zip(self.variables['observation'], obs))
+
+        obs_dict['day'] = time_info[0]
+        obs_dict['month'] = time_info[1]
+        obs_dict['hour'] = time_info[2]
+
+        return np.array(list(obs_dict.values()), dtype=np.float32)
 
     def step(self,
              action: Union[int,
@@ -199,22 +268,6 @@ class EplusEnv(gym.Env):
 
         return np.array(list(obs_dict.values()),
                         dtype=np.float32), reward, done, info
-
-    def reset(self) -> np.ndarray:
-        """Reset the environment.
-
-        Returns:
-            np.ndarray: Current observation.
-        """
-        # Change to next episode
-        time_info, obs, done = self.simulator.reset(self.weather_variability)
-        obs_dict = dict(zip(self.variables['observation'], obs))
-
-        obs_dict['day'] = time_info[0]
-        obs_dict['month'] = time_info[1]
-        obs_dict['hour'] = time_info[2]
-
-        return np.array(list(obs_dict.values()), dtype=np.float32)
 
     def render(self, mode: str = 'human') -> None:
         """Environment rendering.

--- a/sinergym/simulators/eplus.py
+++ b/sinergym/simulators/eplus.py
@@ -159,12 +159,10 @@ class EnergyPlus(object):
         eplus_working_dir = self._config.set_episode_working_dir()
         # Getting IDF, WEATHER, VARIABLES and OUTPUT path for current episode
         eplus_working_idf_path = self._config.save_building_model()
-        eplus_working_var_path = (eplus_working_dir + '/' + 'variables.cfg')
+        eplus_working_var_path = self._config.save_variables_conf()
         eplus_working_out_path = (eplus_working_dir + '/' + 'output')
         eplus_working_weather_path = self._config.apply_weather_variability(
             variation=weather_variability)
-        # Copy the variable.cfg file to the working dir
-        copyfile(self._variable_path, eplus_working_var_path)
 
         self._create_socket_cfg(self._host,
                                 self._port,

--- a/sinergym/simulators/eplus.py
+++ b/sinergym/simulators/eplus.py
@@ -35,7 +35,7 @@ class EnergyPlus(object):
             eplus_path: str,
             weather_path: str,
             bcvtb_path: str,
-            variable_path: str,
+            variables_path: str,
             idf_path: str,
             env_name: str,
             act_repeat: int = 1,
@@ -47,7 +47,7 @@ class EnergyPlus(object):
             eplus_path (str):  EnergyPlus installation path.
             weather_path (str): EnergyPlus weather file (.epw) path.
             bcvtb_path (str): BCVTB installation path.
-            variable_path (str): Path to variables file.
+            variables_path (str): Path to variables file.
             idf_path (str): EnergyPlus input description file (.idf) path.
             env_name (str): The environment name.
             act_repeat (int, optional): The number of times to repeat the control action. Defaults to 1.
@@ -81,7 +81,7 @@ class EnergyPlus(object):
         # Path attributes
         self._eplus_path = eplus_path
         self._weather_path = weather_path
-        self._variable_path = variable_path
+        self._variables_path = variables_path
         self._idf_path = idf_path
         # Episode existed
         self._episode_existed = False
@@ -95,6 +95,7 @@ class EnergyPlus(object):
         self._config = Config(
             idf_path=self._idf_path,
             weather_path=self._weather_path,
+            variables_path=self._variables_path,
             env_name=self._env_name,
             max_ep_store=self._max_ep_data_store_num,
             extra_config=config_params)

--- a/sinergym/simulators/eplus.py
+++ b/sinergym/simulators/eplus.py
@@ -40,7 +40,7 @@ class EnergyPlus(object):
             env_name: str,
             act_repeat: int = 1,
             max_ep_data_store_num: int = 10,
-            config_params: Optional[Dict[str, Any]] = None):
+            config_params: Dict[str, Any] = {}):
         """EnergyPlus simulation class.
 
         Args:
@@ -52,7 +52,7 @@ class EnergyPlus(object):
             env_name (str): The environment name.
             act_repeat (int, optional): The number of times to repeat the control action. Defaults to 1.
             max_ep_data_store_num (int, optional): The number of simulation results to keep. Defaults to 10.
-            config_params (Optional[Dict[str, Any]], optional): Dictionary with all extra configuration for simulator. Defaults to None.
+            config_params (Dict[str, Any]): Dictionary with all extra configuration for simulator. Defaults to empty Dict.
         """
         self._env_name = env_name
         self._thread_name = threading.current_thread().getName()

--- a/sinergym/utils/config.py
+++ b/sinergym/utils/config.py
@@ -196,9 +196,10 @@ class Config(object):
             xmlstr = minidom.parseString(
                 ET.tostring(self.variables_custom)).toprettyxml(
                 indent="   ")
-            new_variable_path = self.episode_path + '/variables.cfg'
-            with open(new_variable_path, "w") as f:
+            episode_variables_path = self.episode_path + '/variables.cfg'
+            with open(episode_variables_path, "w") as f:
                 f.write(xmlstr)
+            return episode_variables_path
         else:
             raise RuntimeError(
                 '[Simulator Config] Episode path should be set before saving variables.cfg.'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Sinergym will have dynamic observation and action space in gym constructor (current static definition as default configuration).

## Motivation and Context

- [x] I have raised an issue to propose this change ([required](https://github.com/jajimer/sinergym/blob/main/CONTRIBUTING.md) for new features and bug fixes)

We have available a list of environments in which we specify, among other things, the space of actions and observations using XML configuration files; the variables that make up the observations and actions, on the one hand, and the spaces on the other.

The objective is that this functionality remains intact (when the space is not defined by the user), but giving the possibility of defining a customized space of actions and observations independently of the environment being used.

<!--- e.g You can use the syntax `fixes #100` if this solves the issue #100 -->
Fixes #103 
Fixes #6

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)
- [ ] Others

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/jajimer/sinergym/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [ ] I have updated the tests.
- [x] I have updated the documentation accordingly.
- [x] I have reformatted the code using `autopep8` second level aggressive.
- [x] I have reformatted the code using `isort`.
- [x] I have ensured `cd docs && make spelling && make html` pass (**required** if documentation has been updated.)
- [x] I have ensured `pytest tests/ -vv` pass. (**required**).
- [x] I have ensured `pytype -d import-error sinergym/` pass. (**required**)

## Changelog:

- Added extra conf observation and action space manipulation in order to generate our own XML for Energyplus
- Added simulator config for dynamic variables

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/-->